### PR TITLE
Interface client, DB optimizations, Client timeout feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### RethinkDB
 rethinkdb_data/
+interface.cfg
 
 ### Python template
 # Byte-compiled / optimized / DLL files

--- a/interface_client.py
+++ b/interface_client.py
@@ -39,18 +39,17 @@ class InterfaceClient(object):
         self.key = key
         return True
 
-    def pow_update(self, request_id, service_id, client_id, pow_type, time_req, time_res):
-        # TODO finish later, including difficulty
+    def pow_update(self, request_id, service_id, client_id, pow_type, pow_difficulty, time_req, time_res):
         if not self.ready:
             return False
 
         pow_js = json.dumps({
-            'action': 'pow_request',
             'api_key': self.key,
             'request_id': request_id,
             'service_id': service_id,
             'client_id': client_id,
             'pow_type': pow_type,
+            'pow_difficulty': pow_difficulty,
             'time_requested': formatted_time(time_req),
             'time_responded': formatted_time(time_res)
         })

--- a/interface_client.py
+++ b/interface_client.py
@@ -1,0 +1,89 @@
+import requests
+import json
+import configparser
+from threading import Thread
+
+def formatted_time(t):
+    return t.strftime("%Y-%m-%d %H:%M:%S.{:d}".format(int(t.microsecond/1e4)))
+
+
+def post_js(js, uri):
+    try:
+        res = requests.post(uri, headers={"Content-Type": "application/json"}, data=js)
+        if res.status_code != 200:
+            print('Failed to send data to interface URI {}:\n{}'.format(uri, js))
+            print('{}\n{}'.format(res.status_code, res.text))
+    except Exception as e:
+        print('Failed to send data to interface URI {}:\n{}'.format(uri, js))
+        print('{}: {}'.format(type(e).__name__, e))
+
+
+class InterfaceClient(object):
+    def __init__(self):
+        self.ready = False
+
+
+    def read_config(self, config_path):
+        try:
+            config = configparser.ConfigParser()
+            config.read(config_path)
+            server = config.get('DEFAULT', 'server')
+            key = config.get('DEFAULT', 'key')
+        except Exception as e:
+            print('Error reading interface config file: {}'.format(e))
+            self.ready = False
+            return False
+
+        self.ready = True
+        self.server = server
+        self.key = key
+        return True
+
+    def pow_update(self, request_id, service_id, client_id, pow_type, time_req, time_res):
+        # TODO finish later, including difficulty
+        if not self.ready:
+            return False
+
+        pow_js = json.dumps({
+            'action': 'pow_request',
+            'api_key': self.key,
+            'request_id': request_id,
+            'service_id': service_id,
+            'client_id': client_id,
+            'pow_type': pow_type,
+            'time_requested': formatted_time(time_req),
+            'time_responded': formatted_time(time_res)
+        })
+
+        t = Thread(target=post_js, args=[pow_js, self.server+'pow_update'])
+        t.daemon = True
+        t.start()
+        return True  # handled, not necessarily ok
+
+    def clients_update(self, client_list):
+        if not self.ready:
+            return False
+
+        pow_js = json.dumps({
+            'api_key': self.key,
+            'clients': client_list
+        })
+
+        t = Thread(target=post_js, args=[pow_js, self.server+'client_update'])
+        t.daemon = True
+        t.start()
+        return True  # handled, not necessarily ok
+
+    def services_update(self, service_list):
+        if not self.ready:
+            return False
+
+        pow_js = json.dumps({
+            'api_key': self.key,
+            'services': service_list
+        })
+
+        t = Thread(target=post_js, args=[pow_js, self.server+'service_update'])
+        t.daemon = True
+        t.start()
+        return True  # handled, not necessarily ok

--- a/run.py
+++ b/run.py
@@ -138,10 +138,10 @@ class Work(tornado.web.RequestHandler):
                 if ws not in wss_work:
                     ws.write_message(message)
                     wss_work.append(ws)
-                    return '{"status":"sent"}'
-                else:
-                    print_time(str(ws) + " already in use")
-        return '{"status":"failed"}'
+                    return ws
+
+        # no clients
+        return None
 
     @gen.coroutine
     def get_work_via_ws(self, hash_hex):
@@ -171,7 +171,7 @@ class Work(tornado.web.RequestHandler):
             send_result = yield self.ws_demand('{"hash" : "%s", "type" : "urgent", "threshold" : "%s"}' % (hash_hex,threshold_str))
 
             # If no clients, mark this account in DB
-            if send_result == '{"status" : "failed"}':
+            if not send_result:
                 print_time("No clients to to work for account %s" % account)
                 error = 'no_clients'
                 break

--- a/run.py
+++ b/run.py
@@ -289,14 +289,14 @@ class Work(tornado.web.RequestHandler):
             if work_output == WorkState.needs.value or work_output == WorkState.doing.value:
                 print_time("Empty work, get new")
                 work_output, client_id, threshold = yield self.get_work_via_ws(hash_hex)
-                work_type = 'on_demand'
+                work_type = 'O'
             else:
-                work_type = 'precached'
+                work_type = 'P'
         else:
             # 3 If not then request pow via websockets
             print_time('Not in DB, getting on demand...')
             work_output, client_id, threshold = yield self.get_work_via_ws(hash_hex)
-            work_type = 'on_demand'
+            work_type = 'O'
 
         complete_time = datetime.datetime.now(timezone)
 
@@ -460,7 +460,7 @@ class WSHandler(tornado.websocket.WebSocketHandler):
         elif work_type == 'urgent_only':
             # Add to demand
             wss_demand.append(self)
-            self.type = 'U'
+            self.type = 'O'
         else:
             raise Exception('Invalid work type {}'.format(work_type))
 

--- a/run.py
+++ b/run.py
@@ -194,6 +194,7 @@ class Work(tornado.web.RequestHandler):
                 yield rethinkdb.db("pow").table("hashes").insert(
                     {"account": account, "hash": hash_hex, "work": WorkState.doing.value, "threshold": threshold_str}).run(conn)
 
+        client_id = None
         work_tracker[hash_hex] = -1
         t_start = time.time()
         print_time("Waiting for work...")
@@ -375,7 +376,7 @@ class WSHandler(tornado.websocket.WebSocketHandler):
                 valid = self.validate_work(hash_hex, work, threshold_str)
                 if valid:
                     yield rethinkdb.db("pow").table("hashes").filter(rethinkdb.row['hash'] == hash_hex).update(
-                        {"work": work, "client_id": payout_account}).run(conn)
+                        {"work": work}).run(conn)
                     if hash_hex in hash_to_precache:
                         hash_to_precache.remove(hash_hex)
 

--- a/run.py
+++ b/run.py
@@ -39,7 +39,7 @@ from enum import Enum
 # import datetime
 # from tornado.concurrent import Future, chain_future
 
-TIMEOUT_ON_DEMAND = 10.0
+TIMEOUT_ON_DEMAND = 6.0
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--rai_node_uri", help='rai_nodes uri, usually 127.0.0.1', default='127.0.0.1')


### PR DESCRIPTION
Sorry for making this a single PR.

- Interface client is done, configured by standard ConfigParser from python in a **interface.cfg** file, needs `server` and `key` strings
- Client updates to interface every 10 seconds, service updates every 60 seconds, and PoW update after every request (threaded to not delay the return to service)
- Retry once when sending on-demand and client fails.
- On demand timeout changed to a strict 6 seconds, and clients will be placed in a timeout list for 3 minutes if they fail it.
- More DB r/w optimizations.